### PR TITLE
feat(atoms): add AnimateOnScroll component with IntersectionObserver

### DIFF
--- a/components/atoms/animate-on-scroll.tsx
+++ b/components/atoms/animate-on-scroll.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+interface AnimateOnScrollProps {
+  children: React.ReactNode;
+  /** Stagger delay in ms (default: 0) */
+  delay?: number;
+  /** Slide direction (default: "up") */
+  direction?: "up" | "down" | "left" | "right";
+  /** Animation duration in ms (default: 400) */
+  duration?: number;
+  /** IntersectionObserver threshold 0–1 (default: 0.1) */
+  threshold?: number;
+  /** Animate only on first intersection (default: true) */
+  once?: boolean;
+  /** Additional classes on the wrapper div */
+  className?: string;
+}
+
+// ─── Translate offsets per direction ─────────────────────────────────────────
+const TRANSLATE: Record<NonNullable<AnimateOnScrollProps["direction"]>, string> = {
+  up:    "translateY(24px)",
+  down:  "translateY(-24px)",
+  left:  "translateX(24px)",
+  right: "translateX(-24px)",
+};
+
+// ─── Component ────────────────────────────────────────────────────────────────
+export function AnimateOnScroll({
+  children,
+  delay     = 0,
+  direction = "up",
+  duration  = 400,
+  threshold = 0.1,
+  once      = true,
+  className = "",
+}: AnimateOnScrollProps) {
+  const ref        = useRef<HTMLDivElement>(null);
+  const [visible, setVisible] = useState(false);
+  const [prefersReduced, setPrefersReduced] = useState(false);
+
+  // ── Detect prefers-reduced-motion on mount (client only) ──────────────────
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setPrefersReduced(mq.matches);
+
+    // Also listen for changes (e.g. user toggles OS setting mid-session)
+    const handler = (e: MediaQueryListEvent) => setPrefersReduced(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  // ── IntersectionObserver ──────────────────────────────────────────────────
+  useEffect(() => {
+    // If reduced motion, immediately show — no observer needed
+    if (prefersReduced) {
+      setVisible(true);
+      return;
+    }
+
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setVisible(true);
+            // Disconnect after first trigger when once=true
+            if (once) observer.disconnect();
+          } else if (!once) {
+            // Allow re-animation on scroll back when once=false
+            setVisible(false);
+          }
+        });
+      },
+      { threshold }
+    );
+
+    observer.observe(el);
+
+    // ── Cleanup ────────────────────────────────────────────────────────────
+    return () => observer.disconnect();
+  }, [threshold, once, prefersReduced]);
+
+  // ── Styles ────────────────────────────────────────────────────────────────
+  // Reduced motion: no transition, no offset — children appear instantly
+  const style: React.CSSProperties = prefersReduced
+    ? {}
+    : {
+        opacity:          visible ? 1 : 0,
+        transform:        visible ? "translate(0, 0)" : TRANSLATE[direction],
+        transition:       `opacity ${duration}ms ease, transform ${duration}ms ease`,
+        transitionDelay:  `${delay}ms`,
+        // Prevents CLS by reserving paint layer upfront
+        willChange:       "transform, opacity",
+      };
+
+  return (
+    <div ref={ref} className={className} style={style}>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #20

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## What Changed
Adds the `AnimateOnScroll` reusable atom at `components/atoms/animate-on-scroll.tsx`.

This component wraps any children and reveals them with a fade + slide animation 
when they scroll into the viewport. It is the foundational dependency for issue #10 
which will apply these animations across all landing page sections.

## Implementation Details
- Uses `IntersectionObserver` API via `useRef` + `useEffect` — no external libraries
- Pure CSS transitions — no JS animation frames, no framer-motion
- Cleans up the observer on unmount to prevent memory leaks
- Initial state: `opacity: 0` + translate offset based on `direction` prop
- Observed state: `opacity: 1` + `translate: 0`
- `will-change: transform, opacity` prevents layout shift (CLS)
- Placed at `components/atoms/` per Atomic Design — indivisible UI primitive

## Props
| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `children` | `ReactNode` | — | Content to animate |
| `delay` | `number` | `0` | Stagger delay in ms |
| `direction` | `up \| down \| left \| right` | `"up"` | Slide direction |
| `duration` | `number` | `400` | Transition duration in ms |
| `threshold` | `number` | `0.1` | IntersectionObserver threshold 0–1 |
| `once` | `boolean` | `true` | Animate only on first intersection |
| `className` | `string` | `""` | Additional wrapper classes |

## Usage
```tsx
import { AnimateOnScroll } from "@/components/atoms/animate-on-scroll";

// Single element
<AnimateOnScroll direction="up" delay={0}>
  <FeatureCard title="..." />
</AnimateOnScroll>

// Staggered group
<AnimateOnScroll direction="up" delay={0}>   <Card /> </AnimateOnScroll>
<AnimateOnScroll direction="up" delay={100}> <Card /> </AnimateOnScroll>
<AnimateOnScroll direction="up" delay={200}> <Card /> </AnimateOnScroll>
```

## Accessibility
- Fully respects `prefers-reduced-motion` — children appear instantly with zero 
  animation when the OS setting is enabled
- Listens for live changes to the media query mid-session via `addEventListener`

## Testing Checklist
- [x] Component renders children correctly
- [x] Scrolling to element triggers fade + slide animation
- [x] Stagger delay works across multiple instances with increasing delay
- [x] `once={true}` prevents re-animation on scroll back up
- [x] `once={false}` re-animates when element re-enters viewport
- [x] Reduced motion: children appear instantly, no transition applied
- [x] No layout shift (CLS) from initial hidden state
- [x] Works on mobile touch scroll

## Checklist
- [x] I have read the `CONTRIBUTING.md` guidelines
- [x] My commits follow the Conventional Commits specification
- [x] My commits are atomic and represent singular logical changes
- [x] I have self-reviewed my own code
- [x] I have tested my changes locally and verified they pass linting and builds
- [x] **I have attached a screen recording (mandatory for UI changes)**

